### PR TITLE
RESP parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# RESP-Rawan
+# RESP file Parser
+
+This repository implements a RESP file parser
+
+## In this README 👇
+
+- [Features](#features)
+- [Usage](#usage)
+
+## Features
+ - `NewParser()`  returns a parser object to call our APIs
+ - `Parse()` takes the RESP file lines and parses them into the calling parser object 
+ - `LoadFromFile()` takes a path to an input RESP file and parses it to the calling parser object
+
+## Usage
+
+1. 
+    ```go
+        import github.com/codescalersinternships/RESP-Rawan
+    ```
+
+2. Get a new parser first
+    ```go
+        p := NewParser()
+    ```
+
+3. Example usage:
+    ```go
+        err := p.LoadFromFile(filePath)
+			if err != nil {
+				return err
+		}
+    ```
+
+

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/codescalersinternships/RESP-Rawan
+
+go 1.25.0

--- a/pkg/RESPParser.go
+++ b/pkg/RESPParser.go
@@ -72,7 +72,7 @@ var ErrEmptyFile = errors.New("file is empty")
 var ErrInvalidRESP = errors.New("invalid RESP syntax")
 var ErrUnkType = errors.New("unknown RESP type")
 
-func (p *Parser) parse(lines []string) error {
+func (p *Parser) Parse(lines []string) error {
 	for i := 0; i < len(lines); {
 		element, consumed, err := p.parseOne(lines, i)
 		if err != nil {
@@ -173,6 +173,6 @@ func (p *Parser) LoadFromFile(path string) error {
 	}
 
 	cleanedLines := cleanLines(string(data))
-	p.parse(cleanedLines)
+	p.Parse(cleanedLines)
 	return nil
 }

--- a/pkg/RESPParser.go
+++ b/pkg/RESPParser.go
@@ -104,8 +104,20 @@ func (p *Parser) LoadFromFile(path string) error {
 	if len(data) == 0 {
 		return ErrEmptyFile
 	}
-	lines := strings.Split(string(data), "\r\n")
 
-	p.parse(lines)
+	lines := strings.Split(string(data), "\n")
+
+
+	cleanedLines := make([]string, 0, len(lines))
+	for _,line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		if len(trimmedLine) == 0 {
+			continue 
+		}
+		cleanedLines = append(cleanedLines, trimmedLine)
+	}
+
+
+	p.parse(cleanedLines)
 	return nil
 }

--- a/pkg/RESPParser.go
+++ b/pkg/RESPParser.go
@@ -34,7 +34,8 @@ func (i Integer) Type() string   { return "Integer" }
 func (i Integer) String() string { return fmt.Sprintf(":%d\r\n", i.Value) }
 
 type BulkStrings struct {
-	Value string
+	Length int
+	Value  string
 }
 
 func (b BulkStrings) Type() string   { return "BulkStrings" }
@@ -86,12 +87,44 @@ func (p *Parser) parse(lines []string) error {
 				return ErrInvalidRESP
 			}
 			p.RespList = append(p.RespList, Integer{Value: value})
+		case '$': //Bulk String $<length>\r\n<data>\r\n
+			var length int
+			if _, err := fmt.Sscanf(line[1:], "%d", &length); err != nil {
+				return ErrInvalidRESP
+			}
+
+			if length < 0 { // null bulk string
+				p.RespList = append(p.RespList, BulkStrings{Value: "", Length: -1})
+				continue
+			}
+			value := lines[i+1]
+
+			if len(value) != length {
+				return ErrInvalidRESP
+			}
+
+			p.RespList = append(p.RespList, BulkStrings{Value: value, Length: length})
+			i++
 
 		default:
 			return ErrUnkType
 		}
 	}
 	return nil
+}
+
+func (p *Parser) cleanLines(data string) []string {
+	lines := strings.Split(string(data), "\n")
+
+	cleanedLines := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		if len(trimmedLine) == 0 {
+			continue
+		}
+		cleanedLines = append(cleanedLines, trimmedLine)
+	}
+	return cleanedLines
 }
 
 func (p *Parser) LoadFromFile(path string) error {
@@ -105,19 +138,7 @@ func (p *Parser) LoadFromFile(path string) error {
 		return ErrEmptyFile
 	}
 
-	lines := strings.Split(string(data), "\n")
-
-
-	cleanedLines := make([]string, 0, len(lines))
-	for _,line := range lines {
-		trimmedLine := strings.TrimSpace(line)
-		if len(trimmedLine) == 0 {
-			continue 
-		}
-		cleanedLines = append(cleanedLines, trimmedLine)
-	}
-
-
+	cleanedLines := p.cleanLines(string(data))
 	p.parse(cleanedLines)
 	return nil
 }

--- a/pkg/RESPParser.go
+++ b/pkg/RESPParser.go
@@ -1,0 +1,111 @@
+package pkg
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type RespType interface {
+	Type() string
+	String() string
+}
+
+type SimpleString struct {
+	Value string
+}
+
+func (s SimpleString) Type() string   { return "SimpleString" }
+func (s SimpleString) String() string { return fmt.Sprintf("+%s\r\n", s.Value) }
+
+type SimpleError struct {
+	Value string
+}
+
+func (e SimpleError) Type() string   { return "SimpleError" }
+func (e SimpleError) String() string { return fmt.Sprintf("-%s\r\n", e.Value) }
+
+type Integer struct {
+	Value int
+}
+
+func (i Integer) Type() string   { return "Integer" }
+func (i Integer) String() string { return fmt.Sprintf(":%d\r\n", i.Value) }
+
+type BulkStrings struct {
+	Value string
+}
+
+func (b BulkStrings) Type() string   { return "BulkStrings" }
+func (b BulkStrings) String() string { return fmt.Sprintf("$%d\r\n%s\r\n", len(b.Value), b.Value) }
+
+type Array struct {
+	Values []RespType
+}
+
+func (b Array) Type() string { return "Array" }
+func (a Array) String() string {
+
+	s := fmt.Sprintf("*%d\r\n", len(a.Values))
+	for _, v := range a.Values {
+		s += v.String() + "\r\n"
+	}
+	return s
+}
+
+type Parser struct {
+	RespList []RespType
+}
+
+func NewParser() *Parser {
+	return &Parser{
+		RespList: make([]RespType, 0),
+	}
+}
+
+var ErrFileNotExist = errors.New("file doesn't exist")
+var ErrEmptyFile = errors.New("file is empty")
+
+var ErrInvalidRESP = errors.New("invalid RESP syntax")
+var ErrUnkType = errors.New("unknown RESP type")
+
+func (p *Parser) parse(lines []string) error {
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		switch line[0] {
+		case '+': //simple String
+			p.RespList = append(p.RespList, SimpleString{Value: line[1:]})
+
+		case '-': //simple error
+			p.RespList = append(p.RespList, SimpleError{Value: line[1:]})
+
+		case ':': //integer
+			var value int
+			if _, err := fmt.Sscanf(line[1:], "%d", &value); err != nil {
+				return ErrInvalidRESP
+			}
+			p.RespList = append(p.RespList, Integer{Value: value})
+
+		default:
+			return ErrUnkType
+		}
+	}
+	return nil
+}
+
+func (p *Parser) LoadFromFile(path string) error {
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ErrFileNotExist
+	}
+
+	if len(data) == 0 {
+		return ErrEmptyFile
+	}
+	lines := strings.Split(string(data), "\r\n")
+
+	p.parse(lines)
+	return nil
+}

--- a/pkg/RESPParser.go
+++ b/pkg/RESPParser.go
@@ -97,6 +97,11 @@ func (p *Parser) parse(lines []string) error {
 				p.RespList = append(p.RespList, BulkStrings{Value: "", Length: -1})
 				continue
 			}
+
+			if length == 0 { // empty bulk string
+				p.RespList = append(p.RespList, BulkStrings{Value: "", Length: 0})
+				continue
+			}
 			value := lines[i+1]
 
 			if len(value) != length {

--- a/pkg/RESPParser.go
+++ b/pkg/RESPParser.go
@@ -3,7 +3,6 @@ package pkg
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 )
 
@@ -72,9 +71,9 @@ var ErrEmptyFile = errors.New("file is empty")
 var ErrInvalidRESP = errors.New("invalid RESP syntax")
 var ErrUnkType = errors.New("unknown RESP type")
 
-func (p *Parser) Parse(lines []string) error {
-	for i := 0; i < len(lines); {
-		element, consumed, err := p.parseOne(lines, i)
+func (p *Parser) Parse(data []byte) error {
+	for i := 0; i < len(data); {
+		element, consumed, err := p.parseOne(data[i:])
 		if err != nil {
 			return err
 		}
@@ -84,58 +83,62 @@ func (p *Parser) Parse(lines []string) error {
 	return nil
 }
 
-func (p *Parser) parseOne(lines []string, i int) (RespType, int, error) {
-	line := lines[i]
-	switch line[0] {
-	case '+': //simple String
-		return SimpleString{Value: line[1:]}, 1, nil
+func (p *Parser) parseOne(data []byte) (RespType, int, error) {
 
-	case '-': //simple error
-		return SimpleError{Value: line[1:]}, 1, nil
+	idx := strings.Index(string(data), "\r\n")
+	if idx == -1 {
+		return nil, 0, ErrInvalidRESP
+	}
+	switch data[0] {
+	case '+': //simple String	+OK\r\n
+		return SimpleString{Value: string(data[1:idx])}, idx + 2, nil
 
-	case ':': //integer
+	case '-': //simple error	-Error message\r\n
+		return SimpleError{Value: string(data[1:idx])}, idx + 2, nil
+
+	case ':': //integer		:1000\r\n
 		var value int
-		if _, err := fmt.Sscanf(line[1:], "%d", &value); err != nil {
+		if _, err := fmt.Sscanf(string(data[1:idx]), "%d", &value); err != nil {
 			return nil, 0, ErrInvalidRESP
 		}
-		return Integer{Value: value}, 1, nil
-	case '$': //Bulk String $<length>\r\n<data>\r\n
+		return Integer{Value: value}, idx + 2, nil
+
+	case '$': //Bulk String		$<length>\r\n<data>\r\n
 		var length int
-		if _, err := fmt.Sscanf(line[1:], "%d", &length); err != nil {
+		if _, err := fmt.Sscanf(string(data[1:idx]), "%d", &length); err != nil {
 			return nil, 0, ErrInvalidRESP
 		}
 
-		if length < 0 { // null bulk string
-			return BulkStrings{Value: "", Length: -1}, 1, nil
+		if length < 0 { // null bulk string		$-1\r\n
+			return BulkStrings{Value: "", Length: -1}, idx + 2, nil
 		}
 
-		if length == 0 { // empty bulk string
-			return BulkStrings{Value: "", Length: 0}, 1, nil
-		}
-		value := lines[i+1]
-
-		if len(value) != length {
-			return nil, 0, ErrInvalidRESP
+		if length == 0 { // empty bulk string 		$0\r\n\r\n
+			return BulkStrings{Value: "", Length: 0}, idx + 4, nil
 		}
 
-		return BulkStrings{Value: value, Length: length}, 2, nil
+		start := idx + 2
+		end := start + length
+		value := string(data[start:end])
+
+		return BulkStrings{Value: value, Length: length}, end + 2, nil
 
 	case '*': //Array *<count>\r\n<value1>\r\n<value2>\r\n...
 		var length int
-		if _, err := fmt.Sscanf(line[1:], "%d", &length); err != nil {
+		if _, err := fmt.Sscanf(string(data[1:idx]), "%d", &length); err != nil {
 			return nil, 0, ErrInvalidRESP
 		}
 
 		if length == 0 { // empty array
-			return Array{Values: make([]RespType, 0), Length: 0}, 1, nil
+			return Array{Values: make([]RespType, 0), Length: 0}, idx + 2, nil
 		}
 
 		arr := Array{Values: make([]RespType, 0, length), Length: length}
 
-		consumed := 1 // already consumed the count line
+		consumed := idx + 2 // already consumed the count line
 
 		for j := 0; j < length; j++ {
-			element, parsed, err := p.parseOne(lines, i+consumed)
+			element, parsed, err := p.parseOne(data[consumed:])
 			if err != nil {
 				return nil, 0, err
 			}
@@ -145,34 +148,4 @@ func (p *Parser) parseOne(lines []string, i int) (RespType, int, error) {
 		return arr, consumed, nil
 	}
 	return nil, 0, ErrUnkType
-}
-
-func cleanLines(data string) []string {
-	lines := strings.Split(string(data), "\n")
-
-	cleanedLines := make([]string, 0, len(lines))
-	for _, line := range lines {
-		trimmedLine := strings.TrimSpace(line)
-		if len(trimmedLine) == 0 {
-			continue
-		}
-		cleanedLines = append(cleanedLines, trimmedLine)
-	}
-	return cleanedLines
-}
-
-func (p *Parser) LoadFromFile(path string) error {
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return ErrFileNotExist
-	}
-
-	if len(data) == 0 {
-		return ErrEmptyFile
-	}
-
-	cleanedLines := cleanLines(string(data))
-	p.Parse(cleanedLines)
-	return nil
 }

--- a/pkg/RESPParser.go
+++ b/pkg/RESPParser.go
@@ -42,6 +42,7 @@ func (b BulkStrings) Type() string   { return "BulkStrings" }
 func (b BulkStrings) String() string { return fmt.Sprintf("$%d\r\n%s\r\n", len(b.Value), b.Value) }
 
 type Array struct {
+	Length int
 	Values []RespType
 }
 
@@ -50,7 +51,7 @@ func (a Array) String() string {
 
 	s := fmt.Sprintf("*%d\r\n", len(a.Values))
 	for _, v := range a.Values {
-		s += v.String() + "\r\n"
+		s += v.String()
 	}
 	return s
 }
@@ -72,53 +73,81 @@ var ErrInvalidRESP = errors.New("invalid RESP syntax")
 var ErrUnkType = errors.New("unknown RESP type")
 
 func (p *Parser) parse(lines []string) error {
-	for i := 0; i < len(lines); i++ {
-		line := lines[i]
-		switch line[0] {
-		case '+': //simple String
-			p.RespList = append(p.RespList, SimpleString{Value: line[1:]})
-
-		case '-': //simple error
-			p.RespList = append(p.RespList, SimpleError{Value: line[1:]})
-
-		case ':': //integer
-			var value int
-			if _, err := fmt.Sscanf(line[1:], "%d", &value); err != nil {
-				return ErrInvalidRESP
-			}
-			p.RespList = append(p.RespList, Integer{Value: value})
-		case '$': //Bulk String $<length>\r\n<data>\r\n
-			var length int
-			if _, err := fmt.Sscanf(line[1:], "%d", &length); err != nil {
-				return ErrInvalidRESP
-			}
-
-			if length < 0 { // null bulk string
-				p.RespList = append(p.RespList, BulkStrings{Value: "", Length: -1})
-				continue
-			}
-
-			if length == 0 { // empty bulk string
-				p.RespList = append(p.RespList, BulkStrings{Value: "", Length: 0})
-				continue
-			}
-			value := lines[i+1]
-
-			if len(value) != length {
-				return ErrInvalidRESP
-			}
-
-			p.RespList = append(p.RespList, BulkStrings{Value: value, Length: length})
-			i++
-
-		default:
-			return ErrUnkType
+	for i := 0; i < len(lines); {
+		element, consumed, err := p.parseOne(lines, i)
+		if err != nil {
+			return err
 		}
+		p.RespList = append(p.RespList, element)
+		i += consumed
 	}
 	return nil
 }
 
-func (p *Parser) cleanLines(data string) []string {
+func (p *Parser) parseOne(lines []string, i int) (RespType, int, error) {
+	line := lines[i]
+	switch line[0] {
+	case '+': //simple String
+		return SimpleString{Value: line[1:]}, 1, nil
+
+	case '-': //simple error
+		return SimpleError{Value: line[1:]}, 1, nil
+
+	case ':': //integer
+		var value int
+		if _, err := fmt.Sscanf(line[1:], "%d", &value); err != nil {
+			return nil, 0, ErrInvalidRESP
+		}
+		return Integer{Value: value}, 1, nil
+	case '$': //Bulk String $<length>\r\n<data>\r\n
+		var length int
+		if _, err := fmt.Sscanf(line[1:], "%d", &length); err != nil {
+			return nil, 0, ErrInvalidRESP
+		}
+
+		if length < 0 { // null bulk string
+			return BulkStrings{Value: "", Length: -1}, 1, nil
+		}
+
+		if length == 0 { // empty bulk string
+			return BulkStrings{Value: "", Length: 0}, 1, nil
+		}
+		value := lines[i+1]
+
+		if len(value) != length {
+			return nil, 0, ErrInvalidRESP
+		}
+
+		return BulkStrings{Value: value, Length: length}, 2, nil
+
+	case '*': //Array *<count>\r\n<value1>\r\n<value2>\r\n...
+		var length int
+		if _, err := fmt.Sscanf(line[1:], "%d", &length); err != nil {
+			return nil, 0, ErrInvalidRESP
+		}
+
+		if length == 0 { // empty array
+			return Array{Values: make([]RespType, 0), Length: 0}, 1, nil
+		}
+
+		arr := Array{Values: make([]RespType, 0, length), Length: length}
+
+		consumed := 1 // already consumed the count line
+
+		for j := 0; j < length; j++ {
+			element, parsed, err := p.parseOne(lines, i+consumed)
+			if err != nil {
+				return nil, 0, err
+			}
+			arr.Values = append(arr.Values, element)
+			consumed += parsed
+		}
+		return arr, consumed, nil
+	}
+	return nil, 0, ErrUnkType
+}
+
+func cleanLines(data string) []string {
 	lines := strings.Split(string(data), "\n")
 
 	cleanedLines := make([]string, 0, len(lines))
@@ -143,7 +172,7 @@ func (p *Parser) LoadFromFile(path string) error {
 		return ErrEmptyFile
 	}
 
-	cleanedLines := p.cleanLines(string(data))
+	cleanedLines := cleanLines(string(data))
 	p.parse(cleanedLines)
 	return nil
 }

--- a/pkg/RESPParser_test.go
+++ b/pkg/RESPParser_test.go
@@ -1,0 +1,84 @@
+package pkg
+
+import (
+	"testing"
+)
+
+func TestLoadFromFile(t *testing.T) {
+
+	testcases := []struct {
+		testcaseName string
+		filePath     string
+		err          error
+	}{
+		{
+			testcaseName: "Normal case: ini file is present",
+			filePath:     "testdata/resp.txt",
+			err: nil,
+		},
+		{
+			testcaseName: "corner case: empty file",
+			filePath:     "testdata/empty.txt",
+			err:          ErrEmptyFile,
+		},
+		{
+			testcaseName: "corner case: file not found",
+			filePath:     "testdata/filex.txt",
+			err:          ErrFileNotExist,
+		},
+	}
+
+	for _, testcase := range testcases {
+
+		t.Run(testcase.testcaseName, func(t *testing.T) {
+			p := NewParser()
+			err := p.LoadFromFile(testcase.filePath)
+			if err != testcase.err {
+				t.Errorf("expected error: %v, got: %v", testcase.err, err)
+			}
+		})
+	}
+}
+
+
+func TestParse(t *testing.T) {
+
+	const filePath = "testdata/resp.txt"
+
+	testcases := []struct {
+		testcaseName string
+		
+	}{
+		// {
+		// 	testcaseName: "Normal case: ini file is present",
+		// },
+		// {
+		// 	testcaseName: "corner case: empty file",
+		// },
+		{
+			testcaseName: "corner case: file not found",
+		},
+	}
+
+	for _, testcase := range testcases {
+
+		t.Run(testcase.testcaseName, func(t *testing.T) {
+			p := NewParser()
+			p.LoadFromFile(filePath)
+
+			// for _, resp := range p.RespList {
+			// 	switch resp.Type() {
+			// 	case "SimpleString":
+			// 		t.Logf("Simple String: %s", resp)
+			// 	case "SimpleError":
+			// 		t.Logf("Simple Error: %s", resp)
+			// 	case "Integer":
+			// 		t.Logf("Integer: %s", resp)
+			// 	default:
+			// 		t.Errorf("Unknown RESP type: %s", resp.Type())
+			// 	}
+			// }
+			
+		})
+	}
+}

--- a/pkg/RESPParser_test.go
+++ b/pkg/RESPParser_test.go
@@ -138,7 +138,7 @@ func TestParse(t *testing.T) {
 		t.Run(testcase.testcaseName, func(t *testing.T) {
 			p := NewParser()
 			cleanedLines := cleanLines(testcase.fileString)
-			err := p.parse(cleanedLines)
+			err := p.Parse(cleanedLines)
 			if err != testcase.err {
 				t.Errorf("expected error: %v, got: %v", testcase.err, err)
 			}

--- a/pkg/RESPParser_test.go
+++ b/pkg/RESPParser_test.go
@@ -74,6 +74,12 @@ func TestParse(t *testing.T) {
 			fileString:   "$5\r\nhello\r\n",
 			err:          nil,
 			expected:     []RespType{BulkStrings{Value: "hello", Length: 5}},
+		},	
+		{
+			testcaseName: "Empty Bulk String",
+			fileString:   "$0\r\n\r\n",
+			err:          nil,
+			expected:     []RespType{BulkStrings{Value: "", Length: 0}},
 		},
 		{
 			testcaseName: "Null Bulk String",

--- a/pkg/RESPParser_test.go
+++ b/pkg/RESPParser_test.go
@@ -47,31 +47,37 @@ func TestParse(t *testing.T) {
 
 	testcases := []struct {
 		testcaseName string
-		fileLines    []string
+		fileString    string
 		err          error
 		expected     []RespType
 	}{
 		{
 			testcaseName: "Simple String",
-			fileLines:    []string{"+OK"},
+			fileString:    "+OK",
 			err:          nil,
 			expected:     []RespType{SimpleString{Value: "OK"}},
 		},
 		{
 			testcaseName: "Simple Error",
-			fileLines:    []string{"-ERR unknown command"},
+			fileString:    "-ERR unknown command",
 			err:          nil,
 			expected:     []RespType{SimpleError{Value: "ERR unknown command"}},
 		},
 		{
 			testcaseName: "Integer",
-			fileLines:    []string{":12345"},
+			fileString:    ":12345",
 			err:          nil,
 			expected:     []RespType{Integer{Value: 12345}},
 		},
 		{
+			testcaseName: "Bulk String",
+			fileString:    "$5\r\nhello\r\n",
+			err:          nil,
+			expected:     []RespType{BulkStrings{Value: "hello", Length: 5}},
+		},
+		{
 			testcaseName: "Unknown Type",
-			fileLines:    []string{"?Unknown"},
+			fileString:    "?Unknown",
 			err:          ErrUnkType,
 			expected:     make([]RespType, 0),
 		},
@@ -81,7 +87,8 @@ func TestParse(t *testing.T) {
 
 		t.Run(testcase.testcaseName, func(t *testing.T) {
 			p := NewParser()
-			err := p.parse(testcase.fileLines)
+			cleanedLines := p.cleanLines(testcase.fileString)
+			err := p.parse(cleanedLines)
 			if err != testcase.err {
 				t.Errorf("expected error: %v, got: %v", testcase.err, err)
 			}

--- a/pkg/RESPParser_test.go
+++ b/pkg/RESPParser_test.go
@@ -74,7 +74,7 @@ func TestParse(t *testing.T) {
 			fileString:   "$5\r\nhello\r\n",
 			err:          nil,
 			expected:     []RespType{BulkStrings{Value: "hello", Length: 5}},
-		},	
+		},
 		{
 			testcaseName: "Empty Bulk String",
 			fileString:   "$0\r\n\r\n",
@@ -88,6 +88,44 @@ func TestParse(t *testing.T) {
 			expected:     []RespType{BulkStrings{Value: "", Length: -1}},
 		},
 		{
+			testcaseName: "Empty Array",
+			fileString:   "*0\r\n",
+			err:          nil,
+			expected:     []RespType{Array{Values: make([]RespType, 0), Length: 0}},
+		},
+		{
+			testcaseName: "Array",
+			fileString:   "*3\r\n:1\r\n:2\r\n:3\r\n",
+			err:          nil,
+			expected: []RespType{Array{Values: []RespType{
+				Integer{Value: 1},
+				Integer{Value: 2},
+				Integer{Value: 3},
+			}, Length: 3}},
+		},
+		{
+			testcaseName: "All different types",
+			fileString:   "*5\r\n:1\r\n+OK\r\n$6\r\nfoobar\r\n-Error message\r\n*2\r\n:2\r\n+World\r\n",
+			err:          nil,
+			expected: []RespType{
+				Array{
+					Values: []RespType{
+						Integer{Value: 1},
+						SimpleString{Value: "OK"},
+						BulkStrings{Value: "foobar", Length: 6},
+						SimpleError{Value: "Error message"},
+						Array{
+							Values: []RespType{
+								Integer{Value: 2},
+								SimpleString{Value: "World"},
+							},
+							Length: 2,
+						},
+					},
+					Length: 5,
+				}},
+		},
+		{
 			testcaseName: "Unknown Type",
 			fileString:   "?Unknown",
 			err:          ErrUnkType,
@@ -99,14 +137,14 @@ func TestParse(t *testing.T) {
 
 		t.Run(testcase.testcaseName, func(t *testing.T) {
 			p := NewParser()
-			cleanedLines := p.cleanLines(testcase.fileString)
+			cleanedLines := cleanLines(testcase.fileString)
 			err := p.parse(cleanedLines)
 			if err != testcase.err {
 				t.Errorf("expected error: %v, got: %v", testcase.err, err)
 			}
 
 			if !reflect.DeepEqual(p.RespList, testcase.expected) {
-				t.Errorf("expected %v, got %v", testcase.expected, p.RespList)
+				t.Fatalf("mismatch:\nexpected: %#v\ngot: %#v", testcase.expected, p.RespList)
 			}
 
 		})

--- a/pkg/RESPParser_test.go
+++ b/pkg/RESPParser_test.go
@@ -5,97 +5,59 @@ import (
 	"testing"
 )
 
-func TestLoadFromFile(t *testing.T) {
-
-	testcases := []struct {
-		testcaseName string
-		filePath     string
-		err          error
-	}{
-		{
-			testcaseName: "Normal case: ini file is present",
-			filePath:     "testdata/resp.txt",
-			err:          nil,
-		},
-		{
-			testcaseName: "corner case: empty file",
-			filePath:     "testdata/empty.txt",
-			err:          ErrEmptyFile,
-		},
-		{
-			testcaseName: "corner case: file not found",
-			filePath:     "testdata/filex.txt",
-			err:          ErrFileNotExist,
-		},
-	}
-
-	for _, testcase := range testcases {
-
-		t.Run(testcase.testcaseName, func(t *testing.T) {
-			p := NewParser()
-			err := p.LoadFromFile(testcase.filePath)
-			if err != testcase.err {
-				t.Errorf("expected error: %v, got: %v", testcase.err, err)
-			}
-		})
-	}
-}
-
 func TestParse(t *testing.T) {
 
-	const filePath = "testdata/resp.txt"
-
 	testcases := []struct {
 		testcaseName string
-		fileString   string
+		fileStream   []byte
 		err          error
 		expected     []RespType
 	}{
 		{
 			testcaseName: "Simple String",
-			fileString:   "+OK",
+			fileStream:   []byte("+OK\r\n"),
 			err:          nil,
 			expected:     []RespType{SimpleString{Value: "OK"}},
 		},
 		{
 			testcaseName: "Simple Error",
-			fileString:   "-ERR unknown command",
+			fileStream:   []byte("-ERR unknown command\r\n"),
 			err:          nil,
 			expected:     []RespType{SimpleError{Value: "ERR unknown command"}},
 		},
 		{
 			testcaseName: "Integer",
-			fileString:   ":12345",
+			fileStream:   []byte(":12345\r\n"),
 			err:          nil,
 			expected:     []RespType{Integer{Value: 12345}},
 		},
 		{
 			testcaseName: "Bulk String",
-			fileString:   "$5\r\nhello\r\n",
+			fileStream:   []byte("$5\r\nhello\r\n"),
 			err:          nil,
 			expected:     []RespType{BulkStrings{Value: "hello", Length: 5}},
 		},
 		{
 			testcaseName: "Empty Bulk String",
-			fileString:   "$0\r\n\r\n",
+			fileStream:   []byte("$0\r\n\r\n"),
 			err:          nil,
 			expected:     []RespType{BulkStrings{Value: "", Length: 0}},
 		},
 		{
 			testcaseName: "Null Bulk String",
-			fileString:   "$-1\r\n",
+			fileStream:   []byte("$-1\r\n"),
 			err:          nil,
 			expected:     []RespType{BulkStrings{Value: "", Length: -1}},
 		},
 		{
 			testcaseName: "Empty Array",
-			fileString:   "*0\r\n",
+			fileStream:   []byte("*0\r\n"),
 			err:          nil,
 			expected:     []RespType{Array{Values: make([]RespType, 0), Length: 0}},
 		},
 		{
 			testcaseName: "Array",
-			fileString:   "*3\r\n:1\r\n:2\r\n:3\r\n",
+			fileStream:   []byte("*3\r\n:1\r\n:2\r\n:3\r\n"),
 			err:          nil,
 			expected: []RespType{Array{Values: []RespType{
 				Integer{Value: 1},
@@ -105,7 +67,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			testcaseName: "All different types",
-			fileString:   "*5\r\n:1\r\n+OK\r\n$6\r\nfoobar\r\n-Error message\r\n*2\r\n:2\r\n+World\r\n",
+			fileStream:   []byte("*5\r\n:1\r\n+OK\r\n$6\r\nfoobar\r\n-Error message\r\n*2\r\n:2\r\n+World\r\n"),
 			err:          nil,
 			expected: []RespType{
 				Array{
@@ -127,7 +89,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			testcaseName: "Unknown Type",
-			fileString:   "?Unknown",
+			fileStream:   []byte("?Unknown\r\n"),
 			err:          ErrUnkType,
 			expected:     make([]RespType, 0),
 		},
@@ -137,8 +99,7 @@ func TestParse(t *testing.T) {
 
 		t.Run(testcase.testcaseName, func(t *testing.T) {
 			p := NewParser()
-			cleanedLines := cleanLines(testcase.fileString)
-			err := p.Parse(cleanedLines)
+			err := p.Parse(testcase.fileStream)
 			if err != testcase.err {
 				t.Errorf("expected error: %v, got: %v", testcase.err, err)
 			}

--- a/pkg/RESPParser_test.go
+++ b/pkg/RESPParser_test.go
@@ -47,37 +47,43 @@ func TestParse(t *testing.T) {
 
 	testcases := []struct {
 		testcaseName string
-		fileString    string
+		fileString   string
 		err          error
 		expected     []RespType
 	}{
 		{
 			testcaseName: "Simple String",
-			fileString:    "+OK",
+			fileString:   "+OK",
 			err:          nil,
 			expected:     []RespType{SimpleString{Value: "OK"}},
 		},
 		{
 			testcaseName: "Simple Error",
-			fileString:    "-ERR unknown command",
+			fileString:   "-ERR unknown command",
 			err:          nil,
 			expected:     []RespType{SimpleError{Value: "ERR unknown command"}},
 		},
 		{
 			testcaseName: "Integer",
-			fileString:    ":12345",
+			fileString:   ":12345",
 			err:          nil,
 			expected:     []RespType{Integer{Value: 12345}},
 		},
 		{
 			testcaseName: "Bulk String",
-			fileString:    "$5\r\nhello\r\n",
+			fileString:   "$5\r\nhello\r\n",
 			err:          nil,
 			expected:     []RespType{BulkStrings{Value: "hello", Length: 5}},
 		},
 		{
+			testcaseName: "Null Bulk String",
+			fileString:   "$-1\r\n",
+			err:          nil,
+			expected:     []RespType{BulkStrings{Value: "", Length: -1}},
+		},
+		{
 			testcaseName: "Unknown Type",
-			fileString:    "?Unknown",
+			fileString:   "?Unknown",
 			err:          ErrUnkType,
 			expected:     make([]RespType, 0),
 		},

--- a/pkg/RESPParser_test.go
+++ b/pkg/RESPParser_test.go
@@ -50,7 +50,7 @@ func TestParse(t *testing.T) {
 		
 	}{
 		// {
-		// 	testcaseName: "Normal case: ini file is present",
+		// 	testcaseName: "Normal case: file is present",
 		// },
 		// {
 		// 	testcaseName: "corner case: empty file",
@@ -66,18 +66,18 @@ func TestParse(t *testing.T) {
 			p := NewParser()
 			p.LoadFromFile(filePath)
 
-			// for _, resp := range p.RespList {
-			// 	switch resp.Type() {
-			// 	case "SimpleString":
-			// 		t.Logf("Simple String: %s", resp)
-			// 	case "SimpleError":
-			// 		t.Logf("Simple Error: %s", resp)
-			// 	case "Integer":
-			// 		t.Logf("Integer: %s", resp)
-			// 	default:
-			// 		t.Errorf("Unknown RESP type: %s", resp.Type())
-			// 	}
-			// }
+			for _, resp := range p.RespList {
+				switch r := resp.(type) {
+				case SimpleString:
+					t.Log("Simple String", r.Value)
+				case SimpleError:
+					t.Log("Simple Error", r.Value)
+				case Integer:
+					t.Log("Integer", r.Value)
+				default:
+					t.Errorf("Unknown RESP type: %s", resp.Type())
+				}
+			}
 			
 		})
 	}

--- a/pkg/RESPParser_test.go
+++ b/pkg/RESPParser_test.go
@@ -1,6 +1,7 @@
 package pkg
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -14,7 +15,7 @@ func TestLoadFromFile(t *testing.T) {
 		{
 			testcaseName: "Normal case: ini file is present",
 			filePath:     "testdata/resp.txt",
-			err: nil,
+			err:          nil,
 		},
 		{
 			testcaseName: "corner case: empty file",
@@ -40,23 +41,39 @@ func TestLoadFromFile(t *testing.T) {
 	}
 }
 
-
 func TestParse(t *testing.T) {
 
 	const filePath = "testdata/resp.txt"
 
 	testcases := []struct {
 		testcaseName string
-		
+		fileLines    []string
+		err          error
+		expected     []RespType
 	}{
-		// {
-		// 	testcaseName: "Normal case: file is present",
-		// },
-		// {
-		// 	testcaseName: "corner case: empty file",
-		// },
 		{
-			testcaseName: "corner case: file not found",
+			testcaseName: "Simple String",
+			fileLines:    []string{"+OK"},
+			err:          nil,
+			expected:     []RespType{SimpleString{Value: "OK"}},
+		},
+		{
+			testcaseName: "Simple Error",
+			fileLines:    []string{"-ERR unknown command"},
+			err:          nil,
+			expected:     []RespType{SimpleError{Value: "ERR unknown command"}},
+		},
+		{
+			testcaseName: "Integer",
+			fileLines:    []string{":12345"},
+			err:          nil,
+			expected:     []RespType{Integer{Value: 12345}},
+		},
+		{
+			testcaseName: "Unknown Type",
+			fileLines:    []string{"?Unknown"},
+			err:          ErrUnkType,
+			expected:     make([]RespType, 0),
 		},
 	}
 
@@ -64,21 +81,15 @@ func TestParse(t *testing.T) {
 
 		t.Run(testcase.testcaseName, func(t *testing.T) {
 			p := NewParser()
-			p.LoadFromFile(filePath)
-
-			for _, resp := range p.RespList {
-				switch r := resp.(type) {
-				case SimpleString:
-					t.Log("Simple String", r.Value)
-				case SimpleError:
-					t.Log("Simple Error", r.Value)
-				case Integer:
-					t.Log("Integer", r.Value)
-				default:
-					t.Errorf("Unknown RESP type: %s", resp.Type())
-				}
+			err := p.parse(testcase.fileLines)
+			if err != testcase.err {
+				t.Errorf("expected error: %v, got: %v", testcase.err, err)
 			}
-			
+
+			if !reflect.DeepEqual(p.RespList, testcase.expected) {
+				t.Errorf("expected %v, got %v", testcase.expected, p.RespList)
+			}
+
 		})
 	}
 }

--- a/pkg/testdata/resp.txt
+++ b/pkg/testdata/resp.txt
@@ -1,1 +1,6 @@
-+OK\r\n-ERR unknown command 'foo'\r\n:12345\r\n:1\r\n:2\r\n:3\r\n
++OK
+-ERR unknown command 'foo'
+:12345
+:1
+:2
+:3

--- a/pkg/testdata/resp.txt
+++ b/pkg/testdata/resp.txt
@@ -1,0 +1,1 @@
++OK\r\n-ERR unknown command 'foo'\r\n:12345\r\n:1\r\n:2\r\n:3\r\n

--- a/pkg/testdata/resp.txt
+++ b/pkg/testdata/resp.txt
@@ -1,6 +1,6 @@
-+OK
--ERR unknown command 'foo'
-:12345
-:1
-:2
-:3
++OK\r\n
+-ERR unknown command 'foo'\r\n
+:12345\r\n
+:1\r\n
+:2\r\n
+:3\r\n


### PR DESCRIPTION
Issue link: https://github.com/codescalersinternships/home/issues/315
This PR implements the following APIs for RESP files parser and their unit tests:
 - `NewParser()`  returns a parser object to call our APIs
 - `Parse()` takes the RESP file lines and parses them into the calling parser object 
 - `LoadFromFile()` takes a path to an input RESP file and parses it to the calling parser object